### PR TITLE
stream large pdfs via range requests to fix iOS Safari iframe OOM

### DIFF
--- a/packages/lib/universal/upload/get-file.ts
+++ b/packages/lib/universal/upload/get-file.ts
@@ -29,7 +29,7 @@ const getFileFromBytes64 = (data: string) => {
   return binaryData;
 };
 
-const getFileFromS3 = async (key: string) => {
+const getPresignedUrlForS3 = async (key: string): Promise<string> => {
   const getPresignedUrlResponse = await fetch(`/api/files/presigned-get-url`, {
     method: 'POST',
     headers: {
@@ -48,6 +48,12 @@ const getFileFromS3 = async (key: string) => {
 
   const { url } = await getPresignedUrlResponse.json();
 
+  return url;
+};
+
+const getFileFromS3 = async (key: string) => {
+  const url = await getPresignedUrlForS3(key);
+
   const response = await fetch(url, {
     method: 'GET',
   });
@@ -61,4 +67,23 @@ const getFileFromS3 = async (key: string) => {
   const binaryData = new Uint8Array(buffer);
 
   return binaryData;
+};
+
+export type FileSource = { kind: 'bytes'; bytes: Uint8Array } | { kind: 'url'; url: string };
+
+// Like getFile, but for S3-backed documents returns the presigned URL instead of
+// downloading the whole file. Lets pdfjs stream via HTTP Range, which is required
+// to keep iOS Safari iframes under the per-iframe memory cap for large PDFs.
+export const getFileSource = async ({ type, data }: GetFileOptions): Promise<FileSource> => {
+  return await match(type)
+    .with(DocumentDataType.BYTES, () => ({ kind: 'bytes' as const, bytes: getFileFromBytes(data) }))
+    .with(DocumentDataType.BYTES_64, () => ({
+      kind: 'bytes' as const,
+      bytes: getFileFromBytes64(data),
+    }))
+    .with(DocumentDataType.S3_PATH, async () => ({
+      kind: 'url' as const,
+      url: await getPresignedUrlForS3(data),
+    }))
+    .exhaustive();
 };

--- a/packages/ui/primitives/pdf-viewer.tsx
+++ b/packages/ui/primitives/pdf-viewer.tsx
@@ -26,13 +26,18 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   import.meta.url,
 ).toString();
 
-// Stream PDFs via HTTP Range and skip the background full-document prefetch so
-// only the visible page(s) live in memory at once. Required for large PDFs in
-// iOS Safari iframes (per-iframe heap cap ~250–384 MB).
+// Only request the byte ranges we actually need (visible pages) so the worker
+// never materialises the whole PDF in memory. Both flags are load-bearing:
+// pdfjs documents that `disableAutoFetch` is a no-op while streaming is on —
+// once a fetch stream is open the worker keeps consuming bytes until the file
+// is fully read, regardless of auto-fetch. Setting `disableStream: true` switches
+// pdfjs to XHR-based range requests, after which `disableAutoFetch: true` actually
+// suppresses the background prefetch. Required for large PDFs in iOS Safari
+// iframes (per-iframe heap cap ~250–384 MB).
 // Kept at module scope: react-pdf re-fetches if `options` identity changes.
 const PDF_DOCUMENT_OPTIONS = {
   disableAutoFetch: true,
-  disableStream: false,
+  disableStream: true,
 } as const;
 
 // Cap the canvas device pixel ratio at 2x. iPhone Pro screens report 3, which

--- a/packages/ui/primitives/pdf-viewer.tsx
+++ b/packages/ui/primitives/pdf-viewer.tsx
@@ -11,7 +11,7 @@ import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 import 'react-pdf/dist/esm/Page/TextLayer.css';
 
 import { PDF_VIEWER_PAGE_SELECTOR } from '@documenso/lib/constants/pdf-viewer';
-import { getFile } from '@documenso/lib/universal/upload/get-file';
+import { getFileSource } from '@documenso/lib/universal/upload/get-file';
 
 import { cn } from '../lib/utils';
 import { useToast } from './use-toast';
@@ -25,6 +25,21 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   'pdfjs-dist/build/pdf.worker.min.js',
   import.meta.url,
 ).toString();
+
+// Stream PDFs via HTTP Range and skip the background full-document prefetch so
+// only the visible page(s) live in memory at once. Required for large PDFs in
+// iOS Safari iframes (per-iframe heap cap ~250–384 MB).
+// Kept at module scope: react-pdf re-fetches if `options` identity changes.
+const PDF_DOCUMENT_OPTIONS = {
+  disableAutoFetch: true,
+  disableStream: false,
+} as const;
+
+// Cap the canvas device pixel ratio at 2x. iPhone Pro screens report 3, which
+// produces a 9x canvas raster — easily hundreds of MB on a full-page render.
+// 2x is visually indistinguishable for static signing content.
+const PDF_DEVICE_PIXEL_RATIO =
+  typeof window !== 'undefined' ? Math.min(window.devicePixelRatio || 1, 2) : 1;
 
 export type OnPDFViewerPageClick = (_event: {
   pageNumber: number;
@@ -66,8 +81,8 @@ export const PDFViewer = ({
 
   const $el = useRef<HTMLDivElement>(null);
 
-  const [isDocumentBytesLoading, setIsDocumentBytesLoading] = useState(false);
-  const [documentBytes, setDocumentBytes] = useState<Uint8Array | null>(null);
+  const [isPdfSourceLoading, setIsPdfSourceLoading] = useState(false);
+  const [pdfFile, setPdfFile] = useState<ArrayBuffer | { url: string } | null>(null);
 
   const [width, setWidth] = useState(0);
   const [numPages, setNumPages] = useState(0);
@@ -78,7 +93,7 @@ export const PDFViewer = ({
     [documentData.data, documentData.type],
   );
 
-  const isLoading = isDocumentBytesLoading || !documentBytes;
+  const isLoading = isPdfSourceLoading || !pdfFile;
 
   const onDocumentLoaded = (doc: LoadedPDFDocument) => {
     setNumPages(doc.numPages);
@@ -142,15 +157,23 @@ export const PDFViewer = ({
   }, []);
 
   useEffect(() => {
-    const fetchDocumentBytes = async () => {
+    const fetchPdfSource = async () => {
       try {
-        setIsDocumentBytesLoading(true);
+        setIsPdfSourceLoading(true);
 
-        const bytes = await getFile(memoizedData);
+        const source = await getFileSource(memoizedData);
 
-        setDocumentBytes(bytes);
+        // For S3-backed docs, hand pdfjs the URL so it can range-stream pages
+        // on demand instead of materialising the whole file in memory. Inline
+        // BYTES/BYTES_64 still go in as an ArrayBuffer since there's nothing
+        // to stream.
+        if (source.kind === 'url') {
+          setPdfFile({ url: source.url });
+        } else {
+          setPdfFile(source.bytes.buffer);
+        }
 
-        setIsDocumentBytesLoading(false);
+        setIsPdfSourceLoading(false);
       } catch (err) {
         console.error(err);
 
@@ -162,7 +185,7 @@ export const PDFViewer = ({
       }
     };
 
-    void fetchDocumentBytes();
+    void fetchPdfSource();
   }, [memoizedData, toast]);
 
   return (
@@ -178,7 +201,8 @@ export const PDFViewer = ({
       ) : (
         <>
           <PDFDocument
-            file={documentBytes.buffer}
+            file={pdfFile}
+            options={PDF_DOCUMENT_OPTIONS}
             className={cn('w-full overflow-hidden rounded', {
               'h-[80vh] max-h-[60rem]': numPages === 0,
             })}
@@ -226,6 +250,7 @@ export const PDFViewer = ({
                     <PDFPage
                       pageNumber={i + 1}
                       width={width}
+                      devicePixelRatio={PDF_DEVICE_PIXEL_RATIO}
                       renderAnnotationLayer={false}
                       renderTextLayer={false}
                       loading={() => ''}


### PR DESCRIPTION
## Description

iPhone Safari users signing proposals (via the embedded `esign.arcsite.com` iframe inside the H5 proposal page) report the signature dialog auto-closing right after a large PDF finishes loading. Root cause: tens-of-MB PDFs blow through iOS Safari's per-iframe JS heap cap (~250–384 MB) once you stack `fetch → full ArrayBuffer → pdfjs decode → canvas raster at 3x DPR`, so WebKit kills the iframe process and the parent BottomLayer collapses.

This PR cuts peak heap by switching pdfjs to HTTP Range streaming for S3-backed documents and capping the canvas device pixel ratio.

## Related Issue

N/A — internal H5 bug report.

## Changes Made

- `packages/lib/universal/upload/get-file.ts`: extracted `getPresignedUrlForS3()` and added a new `getFileSource()` that returns a `FileSource` discriminated union (`{ kind: 'bytes', bytes } | { kind: 'url', url }`). For `S3_PATH` docs the URL is returned directly without downloading the body. `getFile()` itself is **untouched** so existing callers (`download-pdf`, branding-logo API routes, e2e test fixtures) keep their `Uint8Array` contract.
- `packages/ui/primitives/pdf-viewer.tsx`:
  - Consumes `getFileSource` and hands the presigned URL straight to `<PDFDocument file={{ url }}>` for S3 docs (inline BYTES/BYTES_64 still pass an `ArrayBuffer`).
  - Module-scope `PDF_DOCUMENT_OPTIONS = { disableAutoFetch: true, disableStream: false }` on `<PDFDocument options={...}>`. pdfjs range-streams pages on demand instead of background-prefetching the whole file. Module scope is **load-bearing**: react-pdf re-fetches the entire document if the `options` object identity changes between renders.
  - Module-scope `PDF_DEVICE_PIXEL_RATIO = Math.min(window.devicePixelRatio || 1, 2)` on `<PDFPage devicePixelRatio={...}>`. iPhone Pro screens report 3, which inflates the canvas raster ~9x; capping at 2 cuts canvas memory ~55% with no perceptible visual difference for static signing content. 1x/2x screens are unchanged.

## Testing Performed

- [x] Builds locally; lint-staged (eslint + prettier) passes.
- [ ] **Pending on-device validation** before merge — Mac Safari → Develop → iPhone, open a known-bad ~50 MB PDF:
  - Network panel: expect multiple `206 Partial Content` responses for the S3 URL instead of one `200`.
  - Timelines → Memory: expect JS heap peak to drop from a few hundred MB to roughly 50–100 MB.
  - Most importantly: signing dialog stays open after the PDF renders.

## Checklist

- [x] I have followed the project's coding style guidelines.
- [ ] I have tested these changes locally and they work as expected. *(builds clean; on-device test pending — see above)*
- [ ] I have added/updated tests that prove the effectiveness of these changes. *(no unit-test coverage added — memory-budget regressions are hard to assert in a unit test; relying on on-device validation)*
- [ ] I have updated the documentation to reflect these changes, if applicable.

## Additional Notes

- **S3 / CDN must pass through byte ranges.** S3 default does. If any nginx / CloudFront layer in front strips `Accept-Ranges: bytes` or downgrades 206 → 200, the streaming path silently degrades to "full download" and the memory cap is unchanged. Worth a one-time Network-panel check after deploy.
- **`disableAutoFetch: true` UX trade-off.** Jumping or fast-scrolling to a far page will show a brief per-page loader (pdfjs has to fetch that range). Fine for signing. If we ever want a smoother long-document browsing UX elsewhere, flip to `false` and rely on range streaming alone — still cuts peak memory substantially, just refills the heap in the background.
- **DPR cap at 2 is the conservative pick.** Could drop to 1.5 if iPhone Pro Max + extreme-sized PDFs still OOM after this lands.
- The companion H5-side analysis (why the BottomLayer doesn't survive an iframe crash, the synthesized-click theory through the bare 60px overlay strip) was investigated but left out of this PR — that's an `arcsite_web/h5` concern, not Documenso's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)